### PR TITLE
Automate production deployments

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -45,7 +45,3 @@ jobs:
       # CODE QUALITY
       - name: Run code quality scans
         run: docker-compose -f docker-compose.yml -f ci/docker-compose.ci.yml run app sh ci/code_quality.sh
-
-      # Testing publish script
-      - name: Build and publish artifacts
-        run: docker run -v "$PWD:/app" -e TF_VAR_bucket_name=${{ secrets.TF_VAR_bucket_name }} -e TF_VAR_domains=${{ secrets.TF_VAR_domains }} -e AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }} -e AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} -e AWS_DEFAULT_REGION=us-east-1 ${{ github.repository }}:${{ github.head_ref }} sh ci/publish_build.sh $(git tag -l --sort "v:refname" "*.*.*" | tail -1)

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -48,4 +48,4 @@ jobs:
 
       # Testing publish script
       - name: Build and publish artifacts
-        run: docker run -v "$PWD:/app" -e TF_VAR_bucket_name==${{ secrets.TF_VAR_bucket_name }} -e TF_VAR_domains=${{ secrets.TF_VAR_domains }} -e AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }} -e AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} ${{ github.repository }}:${{ github.head_ref }} sh ci/publish_build.sh $(git tag -l --sort "v:refname" "*.*.*" | tail -1)
+        run: docker run -v "$PWD:/app" -e TF_VAR_bucket_name=${{ secrets.TF_VAR_bucket_name }} -e TF_VAR_domains=${{ secrets.TF_VAR_domains }} -e AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }} -e AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} ${{ github.repository }}:${{ github.head_ref }} sh ci/publish_build.sh $(git tag -l --sort "v:refname" "*.*.*" | tail -1)

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -45,3 +45,7 @@ jobs:
       # CODE QUALITY
       - name: Run code quality scans
         run: docker-compose -f docker-compose.yml -f ci/docker-compose.ci.yml run app sh ci/code_quality.sh
+
+      # Testing publish script
+      - name: Build and publish artifacts
+        run: docker run -v "$PWD:/app" -e TF_VAR_bucket_name -e TF_VAR_domains -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY ${{ github.repository }}:${{ github.head_ref }} sh ci/publish_build.sh $(git tag -l --sort "v:refname" "*.*.*" | tail -1)

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -48,4 +48,4 @@ jobs:
 
       # Testing publish script
       - name: Build and publish artifacts
-        run: docker run -v "$PWD:/app" -e TF_VAR_bucket_name==${{ secrets.TF_VAR_bucket_name }} -e TF_VAR_domains=${{ secrets.TF_VAR_domains }} -e AWS_ACCESS_KEY_ID==${{ secrets.AWS_ACCESS_KEY_ID }} -e AWS_SECRET_ACCESS_KEY==${{ secrets.AWS_SECRET_ACCESS_KEY }} ${{ github.repository }}:${{ github.head_ref }} sh ci/publish_build.sh $(git tag -l --sort "v:refname" "*.*.*" | tail -1)
+        run: docker run -v "$PWD:/app" -e TF_VAR_bucket_name==${{ secrets.TF_VAR_bucket_name }} -e TF_VAR_domains=${{ secrets.TF_VAR_domains }} -e AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }} -e AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} ${{ github.repository }}:${{ github.head_ref }} sh ci/publish_build.sh $(git tag -l --sort "v:refname" "*.*.*" | tail -1)

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -48,4 +48,4 @@ jobs:
 
       # Testing publish script
       - name: Build and publish artifacts
-        run: docker run -v "$PWD:/app" -e TF_VAR_bucket_name -e TF_VAR_domains -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY ${{ github.repository }}:${{ github.head_ref }} sh ci/publish_build.sh $(git tag -l --sort "v:refname" "*.*.*" | tail -1)
+        run: docker run -v "$PWD:/app" -e TF_VAR_bucket_name==${{ secrets.TF_VAR_bucket_name }} -e TF_VAR_domains=${{ secrets.TF_VAR_domains }} -e AWS_ACCESS_KEY_ID==${{ secrets.AWS_ACCESS_KEY_ID }} -e AWS_SECRET_ACCESS_KEY==${{ secrets.AWS_SECRET_ACCESS_KEY }} ${{ github.repository }}:${{ github.head_ref }} sh ci/publish_build.sh $(git tag -l --sort "v:refname" "*.*.*" | tail -1)

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -48,4 +48,4 @@ jobs:
 
       # Testing publish script
       - name: Build and publish artifacts
-        run: docker run -v "$PWD:/app" -e TF_VAR_bucket_name=${{ secrets.TF_VAR_bucket_name }} -e TF_VAR_domains=${{ secrets.TF_VAR_domains }} -e AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }} -e AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} ${{ github.repository }}:${{ github.head_ref }} sh ci/publish_build.sh $(git tag -l --sort "v:refname" "*.*.*" | tail -1)
+        run: docker run -v "$PWD:/app" -e TF_VAR_bucket_name=${{ secrets.TF_VAR_bucket_name }} -e TF_VAR_domains=${{ secrets.TF_VAR_domains }} -e AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }} -e AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} -e AWS_DEFAULT_REGION=us-east-1 ${{ github.repository }}:${{ github.head_ref }} sh ci/publish_build.sh $(git tag -l --sort "v:refname" "*.*.*" | tail -1)

--- a/.github/workflows/tag_main.yml
+++ b/.github/workflows/tag_main.yml
@@ -34,4 +34,4 @@ jobs:
             load: true
             tags: ${{ github.repository }}:${{ github.head_ref }}
       - name: Build and publish artifacts
-        run: docker run -v "$PWD:/app" -e TF_VAR_bucket_name=${{ secrets.TF_VAR_bucket_name }} -e TF_VAR_domains=${{ secrets.TF_VAR_domains }} -e AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }} -e AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} ${{ github.repository }}:${{ github.head_ref }} sh ci/publish_build.sh $(git tag -l --sort "v:refname" "*.*.*" | tail -1)
+        run: docker run -v "$PWD:/app" -e TF_VAR_bucket_name=${{ secrets.TF_VAR_bucket_name }} -e TF_VAR_domains=${{ secrets.TF_VAR_domains }} -e AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }} -e AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} -e AWS_DEFAULT_REGION=us-east-1 ${{ github.repository }}:${{ github.head_ref }} sh ci/publish_build.sh $(git tag -l --sort "v:refname" "*.*.*" | tail -1)

--- a/.github/workflows/tag_main.yml
+++ b/.github/workflows/tag_main.yml
@@ -26,12 +26,12 @@ jobs:
         run: git tag $(bash ci/semver.sh bump patch $(git tag -l --sort "v:refname" "*.*.*" | tail -1))
       - name: Push tag
         run: git push origin --tags
-      - name: Build Docker container with dev/deploy tools
-          uses: docker/build-push-action@v2
-          with:
-            context: .
-            file: ./Dockerfile
-            load: true
-            tags: ${{ github.repository }}:${{ github.head_ref }}
+      - name: Build Docker container
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          load: true
+          tags: ${{ github.repository }}:${{ github.head_ref }}
       - name: Build and publish artifacts
         run: docker run -v "$PWD:/app" -e TF_VAR_bucket_name=${{ secrets.TF_VAR_bucket_name }} -e TF_VAR_domains=${{ secrets.TF_VAR_domains }} -e AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }} -e AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} -e AWS_DEFAULT_REGION=us-east-1 ${{ github.repository }}:${{ github.head_ref }} sh ci/publish_build.sh $(git tag -l --sort "v:refname" "*.*.*" | tail -1)

--- a/.github/workflows/tag_main.yml
+++ b/.github/workflows/tag_main.yml
@@ -34,4 +34,4 @@ jobs:
             load: true
             tags: ${{ github.repository }}:${{ github.head_ref }}
       - name: Build and publish artifacts
-        run: docker run -v "$PWD:/app" -e TF_VAR_bucket_name==${{ secrets.TF_VAR_bucket_name }} -e TF_VAR_domains=${{ secrets.TF_VAR_domains }} -e AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }} -e AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} ${{ github.repository }}:${{ github.head_ref }} sh ci/publish_build.sh $(git tag -l --sort "v:refname" "*.*.*" | tail -1)
+        run: docker run -v "$PWD:/app" -e TF_VAR_bucket_name=${{ secrets.TF_VAR_bucket_name }} -e TF_VAR_domains=${{ secrets.TF_VAR_domains }} -e AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }} -e AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} ${{ github.repository }}:${{ github.head_ref }} sh ci/publish_build.sh $(git tag -l --sort "v:refname" "*.*.*" | tail -1)

--- a/.github/workflows/tag_main.yml
+++ b/.github/workflows/tag_main.yml
@@ -34,4 +34,4 @@ jobs:
             load: true
             tags: ${{ github.repository }}:${{ github.head_ref }}
       - name: Build and publish artifacts
-        run: docker run -v "$PWD:/app" -e TF_VAR_bucket_name==${{ secrets.TF_VAR_bucket_name }} -e TF_VAR_domains=${{ secrets.TF_VAR_domains }} -e AWS_ACCESS_KEY_ID==${{ secrets.AWS_ACCESS_KEY_ID }} -e AWS_SECRET_ACCESS_KEY==${{ secrets.AWS_SECRET_ACCESS_KEY }} ${{ github.repository }}:${{ github.head_ref }} sh ci/publish_build.sh $(git tag -l --sort "v:refname" "*.*.*" | tail -1)
+        run: docker run -v "$PWD:/app" -e TF_VAR_bucket_name==${{ secrets.TF_VAR_bucket_name }} -e TF_VAR_domains=${{ secrets.TF_VAR_domains }} -e AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }} -e AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} ${{ github.repository }}:${{ github.head_ref }} sh ci/publish_build.sh $(git tag -l --sort "v:refname" "*.*.*" | tail -1)

--- a/.github/workflows/tag_main.yml
+++ b/.github/workflows/tag_main.yml
@@ -26,7 +26,12 @@ jobs:
         run: git tag $(bash ci/semver.sh bump patch $(git tag -l --sort "v:refname" "*.*.*" | tail -1))
       - name: Push tag
         run: git push origin --tags
-      - name: Build and publish artifacts (passing in version tag)
-        run: sh ci/publish_build.sh $(git tag -l --sort "v:refname" "*.*.*" | tail -1)
-
- 
+      - name: Build Docker container with dev/deploy tools
+          uses: docker/build-push-action@v2
+          with:
+            context: .
+            file: ./Dockerfile
+            load: true
+            tags: ${{ github.repository }}:${{ github.head_ref }}
+      - name: Build and publish artifacts
+        run: docker run -v "$PWD:/app" -e TF_VAR_bucket_name -e TF_VAR_domains -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY ${{ github.repository }}:${{ github.head_ref }} sh ci/publish_build.sh $(git tag -l --sort "v:refname" "*.*.*" | tail -1)

--- a/.github/workflows/tag_main.yml
+++ b/.github/workflows/tag_main.yml
@@ -34,4 +34,4 @@ jobs:
             load: true
             tags: ${{ github.repository }}:${{ github.head_ref }}
       - name: Build and publish artifacts
-        run: docker run -v "$PWD:/app" -e TF_VAR_bucket_name -e TF_VAR_domains -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY ${{ github.repository }}:${{ github.head_ref }} sh ci/publish_build.sh $(git tag -l --sort "v:refname" "*.*.*" | tail -1)
+        run: docker run -v "$PWD:/app" -e TF_VAR_bucket_name==${{ secrets.TF_VAR_bucket_name }} -e TF_VAR_domains=${{ secrets.TF_VAR_domains }} -e AWS_ACCESS_KEY_ID==${{ secrets.AWS_ACCESS_KEY_ID }} -e AWS_SECRET_ACCESS_KEY==${{ secrets.AWS_SECRET_ACCESS_KEY }} ${{ github.repository }}:${{ github.head_ref }} sh ci/publish_build.sh $(git tag -l --sort "v:refname" "*.*.*" | tail -1)

--- a/ci/publish_build.sh
+++ b/ci/publish_build.sh
@@ -13,22 +13,18 @@ cd $APP_DIR
 git checkout $1
 
 # Initialize Terraform
-# docker run -v "$PWD:/app" -w "$INFRA_DIR" -e TF_VAR_bucket_name -e TF_VAR_domains -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY coloradodigitalservice/co-care-directory terraform init -backend-config="bucket=${TF_VAR_bucket_name}-terraform-state" -backend-config="dynamodb_table=${TF_VAR_bucket_name}-terraform-state"
 cd $INFRA_DIR
 terraform init -backend-config="bucket=${TF_VAR_bucket_name}-terraform-state" -backend-config="dynamodb_table=${TF_VAR_bucket_name}-terraform-state"
 
 # Apply the infrastructure
-# docker run -v "$PWD:/app" -w "$INFRA_DIR" -e TF_VAR_bucket_name -e TF_VAR_domains -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY coloradodigitalservice/co-care-directory terraform apply -auto-approve
 cd $INFRA_DIR
 terraform apply -auto-approve
 
 # Build the application
-# docker run -v "$PWD:/app" coloradodigitalservice/co-care-directory bash -c "npm install && npm run build"
 cd $APP_DIR
 npm install
 npm run build
 
 # Deploy the application
-# docker run -v "$PWD:/app" -e TF_VAR_bucket_name coloradodigitalservice/co-care-directory aws s3 sync build/. s3://$TF_VAR_bucket_name --delete
 cd $APP_DIR
 aws s3 sync build/. s3://$TF_VAR_bucket_name --delete

--- a/ci/publish_build.sh
+++ b/ci/publish_build.sh
@@ -4,7 +4,31 @@
 # Fail if any command exits with a non-zero exit code
 set -e 
 
-# -----
-# REPLACE THE BELOW WITH YOUR COMMANDS
-# -----
-echo "For version tag $1, build the artifacts and publish them (such as building your Docker container or packaging, then pushing to container repo or central package store)"
+# Variables
+APP_DIR="/app"
+INFRA_DIR="$APP_DIR/infra/aws/infra"
+
+# Checkout the new tag
+cd $APP_DIR
+git checkout $1
+
+# Initialize Terraform
+# docker run -v "$PWD:/app" -w "$INFRA_DIR" -e TF_VAR_bucket_name -e TF_VAR_domains -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY coloradodigitalservice/co-care-directory terraform init -backend-config="bucket=${TF_VAR_bucket_name}-terraform-state" -backend-config="dynamodb_table=${TF_VAR_bucket_name}-terraform-state"
+cd $INFRA_DIR
+terraform init -backend-config="bucket=${TF_VAR_bucket_name}-terraform-state" -backend-config="dynamodb_table=${TF_VAR_bucket_name}-terraform-state"
+
+# Apply the infrastructure
+# docker run -v "$PWD:/app" -w "$INFRA_DIR" -e TF_VAR_bucket_name -e TF_VAR_domains -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY coloradodigitalservice/co-care-directory terraform apply -auto-approve
+cd $INFRA_DIR
+terraform apply -auto-approve
+
+# Build the application
+# docker run -v "$PWD:/app" coloradodigitalservice/co-care-directory bash -c "npm install && npm run build"
+cd $APP_DIR
+npm install
+npm run build
+
+# Deploy the application
+# docker run -v "$PWD:/app" -e TF_VAR_bucket_name coloradodigitalservice/co-care-directory aws s3 sync build/. s3://$TF_VAR_bucket_name --delete
+cd $APP_DIR
+aws s3 sync build/. s3://$TF_VAR_bucket_name --delete


### PR DESCRIPTION
Adds a deployment script and GitHub Actions run step for when a branch is merged to `main`. Does a few things in the script:

1. Checkout the highest tag version
2. Sets up Terraform (to sync with the server-side stored state)
3. Sees if there are any infrastructure changes and makes those changes
4. Builds and deploys an updated version of the app

Also updates the `README.md` with revised instructions, particularly for manual deployments in the event of a failure or deploying a dev environment.

**Know issues** (review question: are these worth fixing ATM?):

There's a slight, but unlikely, race condition. If there are rapid fire merges, this can fail for two reasons:

- Terraform will be locked if multiple deployments are happening
- This runs the job in the `main` Dockerfile and deploys code from highest tag number (i.e. likely to be the same). But then it might have a stale or slightly newer `Dockerfile` if a merge rapidly follows